### PR TITLE
Update the way systems declare required components

### DIFF
--- a/magnetic-drift.asd
+++ b/magnetic-drift.asd
@@ -6,7 +6,8 @@
   :license "MIT"
   :version "0.0.1"
   :serial t
-  :depends-on (#:cepl.sdl2
+  :depends-on (#:alexandria
+               #:cepl.sdl2
                #:skitter #:cepl.skitter.sdl2
                #:sdl2-ttf #:cepl.sdl2-ttf
                #:nineveh #:dirt

--- a/physics.lisp
+++ b/physics.lisp
@@ -19,39 +19,38 @@
            :initform 200)))
 
 (define-component-system move-objects-with-velocity (entity-id dt)
-    (velocity-component position-component) ()
-  (with-components ((move velocity-component)
-                    (pos position-component))
-      entity-id
-    (v2-n:+ (slot-value pos 'pos)
-            (v2:*s (slot-value move 'vel)
-                   dt))))
+    ((move velocity-component)
+     (pos position-component))
+    ()
+  (v2-n:+ (slot-value pos 'pos)
+          (v2:*s (slot-value move 'vel)
+                 dt)))
 
 (define-component-system rotate-objects-with-angular-velocity (entity-id dt)
-    (angular-velocity-component rotation-component) ()
-  (with-components ((ang angular-velocity-component)
-                    (rot rotation-component))
-      entity-id
-    (incf (slot-value rot 'rot)
-          (* (slot-value ang 'ang-vel)
-             dt))))
+    ((ang angular-velocity-component)
+     (rot rotation-component))
+    ()
+  (incf (slot-value rot 'rot)
+        (* (slot-value ang 'ang-vel)
+           dt)))
 
 (define-component-system apply-uniform-friction-to-objects (entity-id dt)
-    (velocity-component uniform-friction-component) ()
-  (with-components ((move velocity-component)
-                    (friction uniform-friction-component))
-      entity-id
-    (v2-n:*s (slot-value move 'vel)
-             (- 1f0 (* dt (slot-value friction 'coeff))))))
+    ((move velocity-component)
+     (friction uniform-friction-component))
+    ()
+  (v2-n:*s (slot-value move 'vel)
+           (- 1f0 (* dt (slot-value friction 'coeff)))))
 
 (defvar *collidable-entities* nil)
 (defvar *mobile-collidable-entities* nil)
 
 (define-component-system mark-entities-for-collision (entity-id dt)
-    (collider-component position-component) ()
-  (declare (ignore dt))
+    (collider-component position-component
+     &optional
+     (velocity-component velocity-component))
+    ()
   (push entity-id *collidable-entities*)
-  (when (get-component entity-id 'velocity-component)
+  (when velocity-component
     (push entity-id *mobile-collidable-entities*)))
 
 (defun overlapping-p (a b)

--- a/player.lisp
+++ b/player.lisp
@@ -29,80 +29,76 @@
                :initform 0.5)))
 
 (define-component-system update-car-velocity (entity-id dt)
-    (velocity-component player-input-component rotation-component) ()
-  (with-components ((move velocity-component)
-                    (rot rotation-component)
-                    (input-comp player-input-component))
-      entity-id
-    (with-slots (rot) rot
-      (with-slots (vel) move
-       (let* ((input (y (dir *input*)))
-              (facing-dir (v! (cos rot)
-                              (sin rot)))
-              (forward-speed (v2:dot facing-dir vel))
-              (to-add (v2-n:-
-                       (v2:*s facing-dir
-                              (* (slot-value input-comp 'accell)
-                                 dt
-                                 input))
-                       (v2:*s facing-dir
-                              (if (brake *input*)
-                                  (* forward-speed
-                                     (slot-value input-comp 'brake-strength)
-                                     dt)
-                                  0f0)))))
-         (unless (and (> (v2:dot to-add vel) 0)
-                      (>= (v2:length vel) (slot-value input-comp 'speed)))
-           (v2-n:+ vel
-                   to-add)))))))
+    ((move velocity-component)
+     (rot rotation-component)
+     (input-comp player-input-component))
+    ()
+  (with-slots (rot) rot
+    (with-slots (vel) move
+      (let* ((input (y (dir *input*)))
+             (facing-dir (v! (cos rot)
+                             (sin rot)))
+             (forward-speed (v2:dot facing-dir vel))
+             (to-add (v2-n:-
+                      (v2:*s facing-dir
+                             (* (slot-value input-comp 'accell)
+                                dt
+                                input))
+                      (v2:*s facing-dir
+                             (if (brake *input*)
+                                 (* forward-speed
+                                    (slot-value input-comp 'brake-strength)
+                                    dt)
+                                 0f0)))))
+        (unless (and (> (v2:dot to-add vel) 0)
+                     (>= (v2:length vel) (slot-value input-comp 'speed)))
+          (v2-n:+ vel
+                  to-add))))))
 
 (define-component-system update-car-angular-velocity (entity-id dt)
-    (velocity-component angular-velocity-component rotation-component player-input-component) ()
-  (declare (ignore dt))
-  (with-components ((ang-vel angular-velocity-component)
-                    (input player-input-component)
-                    (vel velocity-component)
-                    (rot rotation-component))
-      entity-id
-    (with-slots (ang-vel) ang-vel
-      (with-slots (vel) vel
-        (with-slots (rot) rot
-          (let ((dir (v! (cos rot)
-                         (sin rot))))
-            (setf ang-vel (* (- (x (dir *input*)))
-                             (slot-value input 'turning-speed)
-                             (/ (min (v2:length-squared vel) 10000f0)
-                                10000f0)
-                             (v2:dot (v2:normalize vel)
-                                              dir)))))))))
-
-(define-component-system apply-directional-friction-to-objects (entity-id dt)
-    (velocity-component directional-friction-component rotation-component) ()
-  (with-components ((vel velocity-component)
-                    (friction directional-friction-component)
-                    (rot rotation-component))
-      entity-id
+    ((ang-vel angular-velocity-component)
+     (input player-input-component)
+     (vel velocity-component)
+     (rot rotation-component))
+    ()
+  (with-slots (ang-vel) ang-vel
     (with-slots (vel) vel
       (with-slots (rot) rot
-        (with-slots (high-coeff low-coeff) friction
-          (v2-n:-
-           vel
-           (let* ((forward (v! (cos rot)
-                               (sin rot)))
-                  (right (- rot (/ pi 2)))
-                  (right (v! (cos right)
-                             (sin right)))
-                  (forward-speed (v2:dot vel forward))
-                  (right-speed (v2:dot vel right))
-                  (forward-speed (* forward-speed low-coeff dt))
-                  (right-speed (* right-speed
-                                  (- high-coeff
-                                     (* (/ high-coeff 1.4)
-                                        (v2:absolute-dot right
-                                                         (v2:normalize vel))))
-                                  dt)))
-             (v2-n:+ (v2-n:*s forward forward-speed)
-                     (v2-n:*s right right-speed)))))))))
+        (let ((dir (v! (cos rot)
+                       (sin rot))))
+          (setf ang-vel (* (- (x (dir *input*)))
+                           (slot-value input 'turning-speed)
+                           (/ (min (v2:length-squared vel) 10000f0)
+                              10000f0)
+                           (v2:dot (v2:normalize vel)
+                                   dir))))))))
+
+(define-component-system apply-directional-friction-to-objects (entity-id dt)
+    ((vel velocity-component)
+     (friction directional-friction-component)
+     (rot rotation-component))
+    ()
+  (with-slots (vel) vel
+    (with-slots (rot) rot
+      (with-slots (high-coeff low-coeff) friction
+        (v2-n:-
+         vel
+         (let* ((forward (v! (cos rot)
+                             (sin rot)))
+                (right (- rot (/ pi 2)))
+                (right (v! (cos right)
+                           (sin right)))
+                (forward-speed (v2:dot vel forward))
+                (right-speed (v2:dot vel right))
+                (forward-speed (* forward-speed low-coeff dt))
+                (right-speed (* right-speed
+                                (- high-coeff
+                                   (* (/ high-coeff 1.4)
+                                      (v2:absolute-dot right
+                                                       (v2:normalize vel))))
+                                dt)))
+           (v2-n:+ (v2-n:*s forward forward-speed)
+                   (v2-n:*s right right-speed))))))))
 
 (define-prototype car (&optional pos rot scale) ((transform pos rot scale))
     ((player-input-component)

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -185,7 +185,7 @@
           (with-blending *blending-params*
             (map-g #'textured-object-quad *quad-stream*
                    :quad->model (world-matrix offset
-                                              rotation
+                                              (float rotation 1f0)
                                               (v2-n:* (v! x y)
                                                       scale))
                    :model->world (world-matrix (slot-value pos-comp 'pos)

--- a/tilemap.lisp
+++ b/tilemap.lisp
@@ -81,43 +81,41 @@
       (eval forms))))
 
 (define-component-system render-tilemap (entity-id alpha)
-    (tilemap-component position-component) ()
-  (declare (ignore alpha))
+    ((tilemap tilemap-component)
+     (pos position-component))
+    ()
   (with-components ((camera-pos position-component)
                     (camera-comp camera-component))
       *camera*
     (when (and camera-pos camera-comp)
-      (with-components ((tilemap tilemap-component)
-                        (pos position-component))
-          entity-id
-        (loop :for row :across (slot-value tilemap 'tiles)
-              :for row-num :from 0
-              :do
-                 (loop :for tile :across row
-                       :for col-num :from 0
-                       :do
-                          (let ((tex-name (gethash tile (slot-value tilemap 'textures))))
-                            (when tex-name
-                              (let ((sam (texture tex-name))
-                                    (tile-size (slot-value tilemap 'tile-size)))
-                                (map-g #'textured-object-quad *quad-stream*
-                                       :quad->model
-                                       (world-matrix (v! 0 0)
-                                                     0
-                                                     (v! tile-size tile-size))
-                                       :model->world
-                                       (world-matrix (v2-n:+
-                                                      (v!
-                                                       (* col-num
-                                                          2 tile-size)
-                                                       (* row-num
-                                                          2 tile-size))
-                                                      (slot-value pos 'pos))
-                                                     0
-                                                     (v! 1 1))
-                                       :world->view
-                                       (view-matrix (slot-value camera-pos 'pos)
-                                                    (let ((scale (/ (zoom camera-comp))))
-                                                      (v! scale scale)))
-                                       :view->projection (ortho-projection)
-                                       :sam sam))))))))))
+      (loop :for row :across (slot-value tilemap 'tiles)
+            :for row-num :from 0
+            :do
+               (loop :for tile :across row
+                     :for col-num :from 0
+                     :do
+                        (let ((tex-name (gethash tile (slot-value tilemap 'textures))))
+                          (when tex-name
+                            (let ((sam (texture tex-name))
+                                  (tile-size (slot-value tilemap 'tile-size)))
+                              (map-g #'textured-object-quad *quad-stream*
+                                     :quad->model
+                                     (world-matrix (v! 0 0)
+                                                   0
+                                                   (v! tile-size tile-size))
+                                     :model->world
+                                     (world-matrix (v2-n:+
+                                                    (v!
+                                                     (* col-num
+                                                        2 tile-size)
+                                                     (* row-num
+                                                        2 tile-size))
+                                                    (slot-value pos 'pos))
+                                                   0
+                                                   (v! 1 1))
+                                     :world->view
+                                     (view-matrix (slot-value camera-pos 'pos)
+                                                  (let ((scale (/ (zoom camera-comp))))
+                                                    (v! scale scale)))
+                                     :view->projection (ortho-projection)
+                                     :sam sam)))))))))


### PR DESCRIPTION
* Systems can now do `(name type)` pairs in required-components in order to bind a variable a variable to the component of that type
* Can also specify `&optional` to start the list of optional components (don't affect filtering)