### PR TITLE
Ui events

### DIFF
--- a/components.lisp
+++ b/components.lisp
@@ -13,8 +13,9 @@
     entity-id))
 
 (defun get-component (entity-id component-name)
-  (when entity-id
-    (gethash component-name (slot-value (gethash entity-id *entities*) 'components))))
+  (let ((entity (gethash entity-id *entities*)))
+    (when entity
+      (gethash component-name (slot-value entity 'components)))))
 
 (defun remove-component (entity-id component-name)
   (when entity-id

--- a/magnetic-drift.asd
+++ b/magnetic-drift.asd
@@ -20,6 +20,7 @@
                (:file "components")
                (:file "systems")
                (:file "rendering")
+               (:file "ui")
                (:file "tilemap")
                (:file "physics")
                (:file "player")

--- a/magnetic-drift.lisp
+++ b/magnetic-drift.lisp
@@ -9,7 +9,11 @@
 
 (defparameter *scene-physics-systems* '(global-move-camera
                                         reset-mouse-over-entity
+                                        size-texture-hitbox
+                                        size-text-hitbox
                                         check-mouse-ui-hitbox
+                                        check-mouse-over-entity
+                                        check-mouse-state
                                         update-car-velocity
                                         update-car-angular-velocity
                                         move-objects-with-velocity

--- a/magnetic-drift.lisp
+++ b/magnetic-drift.lisp
@@ -8,6 +8,7 @@
 (defvar *car* nil)
 
 (defparameter *scene-physics-systems* '(global-move-camera
+                                        check-mouse-ui-hitbox
                                         update-car-velocity
                                         update-car-angular-velocity
                                         move-objects-with-velocity

--- a/magnetic-drift.lisp
+++ b/magnetic-drift.lisp
@@ -8,6 +8,7 @@
 (defvar *car* nil)
 
 (defparameter *scene-physics-systems* '(global-move-camera
+                                        reset-mouse-over-entity
                                         check-mouse-ui-hitbox
                                         update-car-velocity
                                         update-car-angular-velocity

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -19,7 +19,9 @@
                                        render-normal-text
                                        render-ui-texture
                                        render-ui-text
-                                       swap))
+                                       swap
+                                       size-texture-hitbox
+                                       size-text-hitbox))
 
 (defun texture (filename)
   (alexandria:if-let ((tex (gethash filename *textures*)))

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -10,8 +10,6 @@
 (defvar *blending-params* nil)
 
 (defparameter *scene-render-systems* '(resize-viewport
-                                       check-mouse-over-entity
-                                       check-mouse-state
                                        clear-fbo
                                        select-camera
                                        render-tilemap
@@ -19,9 +17,7 @@
                                        render-normal-text
                                        render-ui-texture
                                        render-ui-text
-                                       swap
-                                       size-texture-hitbox
-                                       size-text-hitbox))
+                                       swap))
 
 (defun texture (filename)
   (alexandria:if-let ((tex (gethash filename *textures*)))

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -10,6 +10,8 @@
 (defvar *blending-params* nil)
 
 (defparameter *scene-render-systems* '(resize-viewport
+                                       check-mouse-over-entity
+                                       check-mouse-state
                                        clear-fbo
                                        select-camera
                                        render-tilemap

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -256,6 +256,11 @@
      :rotation rotation
      :scale (v! (x scale) (y scale)))))
 
+(defun ttf-font-from-text-comp (text-comp)
+  (with-slots (font point-size bold italic underline strike-through)
+      text-comp
+    (ttf-font font :point-size point-size :bold bold :italic italic :underline underline :strike-through strike-through)))
+
 (define-prototype normal-text (&key pos rot scale font text) ((transform pos rot scale))
     ((text-component :font font :text text)))
 
@@ -289,7 +294,7 @@
      (rot-comp rotation-component)
      (scale-comp scale-component))
     (camera-component)
-  (let ((font (ttf-font (slot-value text-comp 'font)))
+  (let ((font (ttf-font-from-text-comp text-comp))
         (text (slot-value text-comp 'text)))
     (unless (text-size-zero-p font text)
       (let* ((tex (text-to-tex text font (slot-value text-comp 'color)))
@@ -351,7 +356,7 @@
                     (camera-comp camera-component))
       *camera*
     (when (and camera-pos camera-comp)
-      (let ((font (ttf-font (slot-value text-comp 'font)))
+      (let ((font (ttf-font-from-text-comp text-comp))
             (text (slot-value text-comp 'text)))
         (unless (text-size-zero-p font text)
           (let* ((tex (text-to-tex text font (slot-value text-comp 'color)))

--- a/rendering.lisp
+++ b/rendering.lisp
@@ -367,16 +367,3 @@
                      (render-ui-texture-impl sam offset rotation scale pos anchor)))
               (cepl:free sam)
               (cepl:free tex))))))))
-
-(defclass ui-hitbox-component (component)
-  ((size :initarg :size
-         :initform (v! 1 1))))
-
-(defclass mouse-trigger-component (component)
-  ((callback :initarg :callback
-             :initform (lambda (event) (declare (ignore event))))))
-
-(defmethod copy-component ((component mouse-trigger-component))
-  (with-slots (callback) component
-    (make-instance 'mouse-trigger-component :callback callback)))
-

--- a/ui.lisp
+++ b/ui.lisp
@@ -55,7 +55,7 @@
      (publish-event 'mouse-event (list 'mouse-leave *prev-mouse-over-entity* *prev-mouse-over-local-pos*)))
     (*mouse-over-entity*
      ;; Got it
-     (publish-event 'mouse-event (list 'mouse-stay *mouse-over-entity* *mouse-over-local-pos*)))
+     (publish-event 'mouse-event (list 'mouse-enter *mouse-over-entity* *mouse-over-local-pos*)))
     (t
      ;; Hovering over nothing
      (publish-event 'mouse-event '(mouse-stay nil nil))))

--- a/ui.lisp
+++ b/ui.lisp
@@ -1,0 +1,83 @@
+;; ui.lisp
+
+(in-package :magnetic-drift)
+
+(defclass ui-hitbox-component (component)
+  ((size :initarg :size
+         :initform (v! 1 1))))
+
+(defmethod copy-component ((component ui-hitbox-component))
+  (with-slots (size) component
+    (make-instance 'ui-hitbox-component :size (v! (x size) (y size)))))
+
+(defvar *mouse-over-entity* nil)
+(defvar *mouse-over-local-pos* nil)
+
+(define-component-system check-mouse-ui-hitbox (entity-id alpha)
+    ((ui-pos ui-position-component)
+     (ui-hitbox ui-hitbox-component)
+     &optional
+     (scale-comp scale-component))
+    (rotation-component)
+  (with-slots (anchor pos) ui-pos
+    (with-slots (size) ui-hitbox
+      (let* ((viewport-size (cepl:viewport-resolution (cepl:current-viewport)))
+             (top-left (v2-n:+ (v2-n:* (v2:+ anchor (v2! 1 1)) viewport-size)
+                                      (v2! (x pos) (- (y pos)))))
+             (bottom-right (v2-n:+ (v2:* size (if scale-comp (slot-value scale-comp 'scale) #.(v! 1 1)))
+                                   top-left))
+             (mouse (skitter:mouse))
+             (mouse-pos (skitter:mouse-pos mouse)))
+        ;; Assume AABB need to account for rotation component later
+        (when (and (<= (x top-left) (x mouse-pos) (x bottom-right))
+                   (<= (y top-left) (y mouse-pos) (y bottom-right)))
+          (setf *mouse-over-entity* entity-id
+                *mouse-over-local-pos* (v2:- mouse-pos top-left)))))))
+
+(defvar *prev-mouse-over-entity* nil)
+(defvar *prev-mouse-over-local-pos* nil)
+
+(define-global-system check-mouse-over-entity (alpha)
+  (declare (ignore alpha))
+  (cond
+    ((and *prev-mouse-over-entity* *mouse-over-entity*
+          (= *prev-mouse-over-entity* *mouse-over-entity*))
+     ;; Stayed the same
+     (publish-event 'mouse-event (list 'mouse-stay *mouse-over-entity* *mouse-over-local-pos*)))
+    ((and *prev-mouse-over-entity* *mouse-over-entity*)
+     ;; Changed hands
+     (publish-event 'mouse-event (list 'mouse-leave *prev-mouse-over-entity* *prev-mouse-over-local-pos*))
+     (publish-event 'mouse-event (list 'mouse-enter *mouse-over-entity* *mouse-over-local-pos*)))
+    (*prev-mouse-over-entity*
+     ;; Lost it
+     (publish-event 'mouse-event (list 'mouse-leave *prev-mouse-over-entity* *prev-mouse-over-local-pos*)))
+    (*mouse-over-entity*
+     ;; Got it
+     (publish-event 'mouse-event (list 'mouse-stay *mouse-over-entity* *mouse-over-local-pos*)))
+    (t
+     ;; Hovering over nothing
+     (publish-event 'mouse-event '(mouse-stay nil nil))))
+  (setf *prev-mouse-over-entity* *mouse-over-entity*
+        *prev-mouse-over-local-pos* *mouse-over-local-pos*))
+
+(defvar *mouse-down* nil
+  "True if the mouse left click was down last we checked.")
+
+(define-global-system check-mouse-state (alpha)
+  (declare (ignore alpha))
+  ;; Check for mouse click or release
+  (let ((mouse-down-p (skitter:mouse-down-p 1)))
+    (cond
+      ((and *mouse-down* mouse-down-p)
+       ;; nothing tbd
+       )
+      (mouse-down-p
+       (publish-event 'mouse-event (list 'mouse-click *mouse-over-entity* *mouse-over-local-pos*)))
+      (*mouse-down*
+       (publish-event 'mouse-event (list 'mouse-release *mouse-over-entity* *mouse-over-local-pos*)))
+      (t
+       ;; nothing tbd
+       ))
+    (setf *mouse-down* mouse-down-p)))
+
+

--- a/ui.lisp
+++ b/ui.lisp
@@ -80,4 +80,20 @@
        ))
     (setf *mouse-down* mouse-down-p)))
 
+(defclass mouse-trigger-component (component)
+  ((callback :initarg :callback
+             :initform (lambda (event-type entity-id local-pos)
+                         (declare (ignore event-type entity-id local-pos))))))
 
+(defmethod copy-component ((component mouse-trigger-component))
+  (with-slots (callback) component
+    (make-instance 'mouse-trigger-component :callback callback)))
+
+(define-event-handler dispatch-mouse-event (event) mouse-event
+  (destructuring-bind (event-type entity-id local-pos)
+      event
+    (when entity-id
+      (with-components ((trigger mouse-trigger-component))
+          entity-id
+        (when trigger
+          (funcall (slot-value trigger 'callback) event-type entity-id local-pos))))))

--- a/ui.lisp
+++ b/ui.lisp
@@ -18,11 +18,11 @@
      (ui-hitbox ui-hitbox-component)
      &optional
      (scale-comp scale-component))
-    (rotation-component)
+    ()
   (with-slots (anchor pos) ui-pos
     (with-slots (size) ui-hitbox
       (let* ((viewport-size (cepl:viewport-resolution (cepl:current-viewport)))
-             (top-left (v2-n:+ (v2-n:* (v2:+ anchor (v2! 1 1)) viewport-size)
+             (top-left (v2-n:+ (v2-n:* (v2:+ anchor (v2! 1 1)) viewport-size #.(v2! 1/2 1/2))
                                       (v2! (x pos) (- (y pos)))))
              (bottom-right (v2-n:+ (v2:* size (if scale-comp (slot-value scale-comp 'scale) #.(v! 1 1)))
                                    top-left))

--- a/ui.lisp
+++ b/ui.lisp
@@ -22,10 +22,12 @@
   (with-slots (anchor pos) ui-pos
     (with-slots (size) ui-hitbox
       (let* ((viewport-size (cepl:viewport-resolution (cepl:current-viewport)))
+             (scale-vec (if scale-comp (slot-value scale-comp 'scale) #.(v! 1 1)))
+             (scaled-size (v2:* scale-vec size))
              (top-left (v2-n:+ (v2-n:* (v2:+ anchor (v2! 1 1)) viewport-size #.(v2! 1/2 1/2))
-                                      (v2! (x pos) (- (y pos)))))
-             (bottom-right (v2-n:+ (v2:* size (if scale-comp (slot-value scale-comp 'scale) #.(v! 1 1)))
-                                   top-left))
+                               (v2! (x pos) (- (y pos)))
+                               (v2! (* (x scaled-size) -1/2) (* (y scaled-size) -1/2))))
+             (bottom-right (v2-n:+ scaled-size top-left))
              (mouse (skitter:mouse))
              (mouse-pos (skitter:mouse-pos mouse)))
         ;; Assume AABB need to account for rotation component later

--- a/ui.lisp
+++ b/ui.lisp
@@ -104,3 +104,20 @@
           entity-id
         (when trigger
           (funcall (slot-value trigger 'callback) event-type entity-id local-pos))))))
+
+(define-component-system size-texture-hitbox (entity-id alpha)
+    ((tex-comp texture-component)
+     (hitbox-comp ui-hitbox-component))
+    ()
+  (let* ((sam (texture (slot-value tex-comp 'texture)))
+         (tex (slot-value sam 'texture)))
+    (destructuring-bind (width height) (texture-base-dimensions tex)
+      (setf (slot-value hitbox-comp 'size) (v2! width height)))))
+
+(define-component-system size-text-hitbox (entity-id alpha)
+    ((text-comp text-component)
+     (hitbox-comp ui-hitbox-component))
+    ()
+  (multiple-value-bind (width height)
+      (sdl2-ttf:size-text (ttf-font-from-text-comp text-comp) (slot-value text-comp 'text))
+    (setf (slot-value hitbox-comp 'size) (v2! width height))))

--- a/ui.lisp
+++ b/ui.lisp
@@ -13,6 +13,11 @@
 (defvar *mouse-over-entity* nil)
 (defvar *mouse-over-local-pos* nil)
 
+(define-global-system reset-mouse-over-entity (dt)
+  (declare (ignore dt))
+  (setf *mouse-over-entity* nil
+        *mouse-over-local-pos* nil))
+
 (define-component-system check-mouse-ui-hitbox (entity-id alpha)
     ((ui-pos ui-position-component)
      (ui-hitbox ui-hitbox-component)


### PR DESCRIPTION
This adds features to allow detecting mouse events like enter, stay, leave, click, and release

The `mouse-trigger-component` allows for setting up a `:callback` which gets called with the event type, the entity ID, and the local position of the event
Global handlers can be put on `mouse-event` as well in order to detect these events.

Additionally there's auto-sizing for text and textures